### PR TITLE
Add roadmap and Codex tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Guidelines
+
+This repository uses Codex agents to automate certain development tasks. Contributors should review the task list in [CODEX.md](CODEX.md) before starting work. The roadmap in [docs/ROADMAP.md](docs/ROADMAP.md) explains the intended project phases.
+
+- Follow the tasks in CODEX.md when adding new files or features.
+- Keep docs/ROADMAP.md updated as milestones are reached.
+

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,32 @@
+# Codex Tasks
+
+This file lists tasks for Codex agents working on this repository. They mirror the phases described in [docs/ROADMAP.md](docs/ROADMAP.md).
+
+## Immediate tasks
+
+1. **Repo housekeeping**
+   - Ensure `LICENSE`, `NOTICE`, and `LICENSE-CC-BY-4.0.txt` are present.
+   - Update `README.md` with a minimal badge table.
+2. **Skeleton layout**
+   - Create `/docs` for the white paper (`k3d_whitepaper_v1.md`).
+   - Create `/spec` with `k3d_schema.json` and a stub `glTF_K3D_extension.md`.
+   - Create `/examples` containing `sample_vectors.csv` and `demo.k3d`.
+3. **Hello-World pipeline**
+   - Implement a tiny CLI `k3dgen` in Python.
+   - Read `sample_vectors.csv`, run 3D PCA, and output a glTF scene plus `.k3d` sidecar.
+4. **Lightweight browser viewer**
+   - Under `/viewer`, scaffold a Vite + Three.js demo.
+   - Load the glTF, read `.k3d` metadata, color nodes, and show a hover tooltip.
+5. **Project management setup**
+   - Create a GitHub Projects board with columns Backlog / In-progress / Done.
+   - File issues tracking phases 0–3.
+6. **Continuous Integration**
+   - Add `.github/workflows/ci.yml` running black, flake8, and jest.
+   - Deploy `/viewer` build to GitHub Pages.
+7. **CONTRIBUTING guide**
+   - Draft `CONTRIBUTING.md` covering coding style, branch naming, DCO sign-off, and clip limits.
+8. **Update roadmap**
+   - Keep `docs/ROADMAP.md` current with milestones through 2026.
+
+Agents should reference this file to coordinate efforts and keep contributions aligned with the overall roadmap.
+

--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ Other companion documents expand on this vision:
 
 All code in this repository is released under the Apache‑2.0 License.  The white‑paper and related text documents are distributed under the Creative Commons Attribution 4.0 International (CC‑BY‑4.0) license.  See [`/docs/LICENSE-CC-BY-4.0.txt`](docs/LICENSE-CC-BY-4.0.txt) for the full CC‑BY‑4.0 text.  GitHub may report "No license" for the documentation, but this file is authoritative.
 
+For the development roadmap see [docs/ROADMAP.md](docs/ROADMAP.md). Codex agents coordinating work should consult [CODEX.md](CODEX.md).
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,31 @@
+# Knowledge3D Roadmap
+
+This document outlines the planned phases for getting the Knowledge3D repository into a community‑ready state. Each phase introduces new deliverables and sets expectations for future contributions.
+
+| Phase | Deliverable | Purpose | Owner/Tooling Hints |
+|------|-------------|---------|--------------------|
+| **0. Repo housekeeping (1 day)** | `LICENSE` (Apache‑2.0), `LICENSE-CC-BY-4.0.txt`, `NOTICE`, minimal `README.md` badge table | Legal clarity & polished first impression | Manual commit |
+| **1. Skeleton layout (1 day)** | `/docs` → white‑paper (`k3d_whitepaper_v1.md`), `/spec` → `k3d_schema.json`, `glTF_K3D_extension.md` stub, `/examples` → `sample_vectors.csv`, `demo.k3d` | Gives contributors clear folders |  |
+| **2. "Hello‑World" pipeline (3‑5 days)** | Python CLI `k3dgen` that reads `sample_vectors.csv`, runs PCA → 3D and writes minimal glTF with `.k3d` metadata sidecar | Proves the spec is implementable | `pygltflib`, `scikit-learn` |
+| **3. Lightweight browser viewer (5‑7 days)** | `/viewer` with Vite + Three.js demo that loads glTF, reads `.k3d` JSON, colors nodes and shows basic hover tooltip | Visual "wow" for README GIF | Codex to stub JS |
+| **4. Milestone issues & project board (0.5 day)** | GitHub Projects board with columns (Backlog / In‑progress / Done) and issues for phases 0‑3 | Open‑source workflow clarity | GitHub UI |
+| **5. Continuous integration (CI) (0.5 day)** | `.github/workflows/ci.yml` running black + flake8, jest for viewer, and building/uploading demo to GitHub Pages | Prevents broken demo | `actions/setup-python`, `actions/upload-pages-artifact` |
+| **6. Draft CONTRIBUTING.md (1 day)** | Coding style, branch naming, DCO sign-off, clip limit reminders | Smooth external PRs | Manual draft |
+| **7. Outreach placeholder (ongoing)** | `docs/ROADMAP.md` with 2025‑Q3 "Spec v0.1", Q4 "LOD & AR extension", 2026 "Khronos proposal" | Sets vision for newcomers |  |
+
+**Why this order?**
+
+- Phases 0–1 make the repo public-ready before code.
+- Phase 2 delivers a tangible artifact proving the concept (<100 LOC).
+- Phase 3 provides a browser demo for the README GIF.
+- Phases 4–6 turn the repo from a personal playground into a community project.
+- Phase 7 seeds long-term ambition without blocking immediate progress.
+
+**Tactical hints**
+
+- Keep `k3dgen` tiny: `pandas` → `scikit-learn.PCA(3)` → `pygltflib` mesh of instanced spheres. Embed per‑point color in extras.
+- `.k3d` sidecar: simple JSON `{ id, vector, metadata }[]` to be read by the viewer—no glTF patching yet.
+- Viewer: start with point sprites and `OrbitControls`; add ray‑caster hover later.
+- GIF for README: record the viewer rotating the demo cloud—30 fps, 6 s loop.
+- CI: any commit touching `/viewer` should auto‑deploy to `gh-pages`, so folks can click‑try without cloning.
+


### PR DESCRIPTION
## Summary
- document project phases in `docs/ROADMAP.md`
- provide instructions for Codex agents in `CODEX.md`
- reference roadmap and tasks from `README.md`
- add `AGENTS.md` to guide repo automation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68891ffa831083249bcbc55bdd812fc9