### PR TITLE
docs: add OpenAI cookbook summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Other companion documents expand on this vision:
 * **Historical inspiration.** [Lessons from Early 3D Interfaces and Apollo&nbsp;11](docs/fsn_apollo_inspiration.md) reflects on SGI's 3D file navigator \(as seen in *Jurassic Park*\) and NASA's modular software practices.
 * **Collaborative research.** "Spatial Web K3D Gemini Deep Research Report 2" combines insights from **OpenAI GPT o3 Deep Research** with a final write‑up produced by **Google Gemini&nbsp;2.5&nbsp;Pro/Flash**.
 * **Temporal agents and knowledge graphs.** [Temporal Agents with Knowledge Graphs](docs/openai_temporal_agents_cookbook.md) distills takeaways from the [OpenAI cookbook notebook](https://github.com/openai/openai-cookbook/blob/main/examples/partners/temporal_agents_with_knowledge_graphs/temporal_agents_with_knowledge_graphs.ipynb).
+* **Eval-driven pipeline design.** [Eval-Driven System Design](docs/openai_eval_driven_system_design_cookbook.md) shows how rigorous evaluations steer autonomous K3D workflows.
+* **Voice agents via MCP.** [MCP-Powered Agentic Voice Framework](docs/openai_mcp_voice_agents_cookbook.md) demonstrates orchestrating tool-calling voice interfaces with the Model Context Protocol.
+* **Model selection playbook.** [Practical Guide for Model Selection](docs/openai_model_selection_cookbook.md) offers decision frameworks for choosing among GPT-4.1, o3, and o4-mini.
+* **Graph-based retrieval.** [RAG with Graph Databases](docs/openai_rag_graph_db_cookbook.md) combines Neo4j graphs and LLMs for relationship-aware context fetching.
+* **3D embedding plots.** [Visualizing Embeddings in 3D](docs/openai_visualizing_embeddings_3d_cookbook.md) applies PCA to project high-dimensional vectors into spatial plots.
+* **Vector store integrations.** [Vector Database Guides](docs/openai_vector_database_guides.md) catalog storage options for semantic search.
+* **Dynamic tool execution.** [Dynamic Code Interpreter for Agents](docs/openai_dynamic_code_interpreter_cookbook.md) explores on-the-fly code generation and execution with o3-mini.
 * **Manus AI perspective.** The PDFs "The K3D Advantage: A Paradigm Shift for Internal AI Memory" and "The K3D Catalyst: Fostering Human-Like Reasoning and Intuition in AI" are both signed by **Manus&nbsp;AI**.
 * **AR vision with an AI coauthor.** "Integrating Augmented Reality and AI: New Frontiers in Training, Learning, and Exploration" expands on Daniel Campos Ramos' ideas in partnership with an **AI assistant**.
 * **Interactive demo.** The HTML file "K3D Gemini report" showcases a simple web report generated using **Google Gemini**.

--- a/docs/openai_dynamic_code_interpreter_cookbook.md
+++ b/docs/openai_dynamic_code_interpreter_cookbook.md
@@ -1,0 +1,12 @@
+# Dynamic Code Interpreter for Agents
+
+This document summarizes insights from the OpenAI cookbook notebook ["Build Your Own Code Interpreter - Dynamic Tool Generation and Execution With o3-mini"](https://github.com/openai/openai-cookbook/blob/main/examples/object_oriented_agentic_approach/Secure_code_interpreter_tool_for_LLM_agents.ipynb) and relates them to the Knowledge3D (K3D) project.
+
+> "We explore a more flexible paradigm – to **dynamically generate tools** using LLM models (in this case o3-mini), with ability to execute the tool using a code interpreter."
+
+## Insights for K3D
+
+1. **On-the-fly analysis** – Allow K3D agents to spawn custom analysis scripts that compute statistics or transform embeddings without predefining every tool.
+2. **Secure execution** – Adapt the cookbook's sandboxed interpreter patterns to run generated code safely when users request ad-hoc calculations inside the knowledge universe.
+3. **Extensible workflows** – Dynamic tool creation lets researchers prototype new graph algorithms or visualization tweaks directly from natural language commands.
+

--- a/docs/openai_eval_driven_system_design_cookbook.md
+++ b/docs/openai_eval_driven_system_design_cookbook.md
@@ -1,0 +1,14 @@
+# Eval-Driven System Design
+
+This document summarizes insights from the OpenAI cookbook notebook ["Eval-Driven System Design"](https://github.com/openai/openai-cookbook/blob/main/examples/partners/eval_driven_system_design/receipt_inspection.ipynb) and relates them to the Knowledge3D (K3D) project.
+
+> "This cookbook provides a **practical**, end-to-end guide on how to effectively use
+evals as the core process in creating a production-grade autonomous system to
+replace a labor-intensive human workflow."
+
+## Insights for K3D
+
+1. **Evaluation-first pipelines** – Treat evals as the backbone of K3D workflows so data ingestion, 3D rendering, and retrieval can be iteratively improved with measurable metrics.
+2. **Autonomous scaling** – Replace manual review of uploaded knowledge assets with automated agents that grade outputs and trigger refinements.
+3. **Real-world feedback loops** – Combine synthetic tests with live user feedback to continually validate navigation quality and model-assisted query accuracy in the K3D universe.
+

--- a/docs/openai_mcp_voice_agents_cookbook.md
+++ b/docs/openai_mcp_voice_agents_cookbook.md
@@ -1,0 +1,12 @@
+# MCP-Powered Agentic Voice Framework
+
+This document summarizes insights from the OpenAI cookbook notebook ["MCP-Powered Agentic Voice Framework"](https://github.com/openai/openai-cookbook/blob/main/examples/partners/mcp_powered_voice_agents/mcp_powered_agents_cookbook.ipynb) and relates them to the Knowledge3D (K3D) project.
+
+> "Agents are becoming the de-facto framework in which we orchestrate various, often specialized, LLMs... Model Context Protocol (MCP) has quickly become the open standard for building Agentic systems."
+
+## Insights for K3D
+
+1. **Voice-driven exploration** – Use MCP to let users speak natural-language queries while agents fetch and narrate results inside the 3D knowledge space.
+2. **Modular tooling** – Decouple K3D services such as search, graph traversal, and rendering into MCP tools so agents can mix and match capabilities securely.
+3. **Cross-model interoperability** – MCP's standard interface allows different AI models to collaborate within shared K3D sessions without bespoke integrations.
+

--- a/docs/openai_model_selection_cookbook.md
+++ b/docs/openai_model_selection_cookbook.md
@@ -1,0 +1,12 @@
+# Practical Guide for Model Selection
+
+This document summarizes insights from the OpenAI cookbook notebook ["Practical Guide for Model Selection for Real-World Use Cases"](https://github.com/openai/openai-cookbook/blob/main/examples/partners/model_selection_guide/model_selection_guide.ipynb) and relates them to the Knowledge3D (K3D) project.
+
+> "This cookbook serves as your practical guide to selecting, prompting, and deploying the right OpenAI model..."
+
+## Insights for K3D
+
+1. **Decision frameworks** – Apply the guide's matrices to choose between GPT-4.1, o3, and o4-mini for tasks like vector generation, spatial reasoning, or AR narration.
+2. **Template prompts** – Reuse the provided prompting patterns to standardize how K3D agents query models across retrieval, summarization, and visualization tasks.
+3. **Cost-performance balance** – Use the cookbook's benchmarks to assign lightweight models for background indexing while reserving powerful models for user-facing interactions.
+

--- a/docs/openai_rag_graph_db_cookbook.md
+++ b/docs/openai_rag_graph_db_cookbook.md
@@ -1,0 +1,12 @@
+# RAG with Graph Databases
+
+This document summarizes insights from the OpenAI cookbook notebook ["Retrieval Augmented Generation with a Graph Database"](https://github.com/openai/openai-cookbook/blob/main/examples/RAG_with_graph_db.ipynb) and relates them to the Knowledge3D (K3D) project.
+
+> "This notebook shows how to use LLMs in combination with [Neo4j](https://neo4j.com/), a graph database, to perform Retrieval Augmented Generation (RAG)."
+
+## Insights for K3D
+
+1. **Relationship-aware retrieval** – Store K3D nodes and edges in a graph database so RAG queries can traverse explicit relationships instead of flat vectors.
+2. **Context injection** – Fetch graph neighborhoods around a query node and pass them to models to reduce hallucinations during spatial exploration.
+3. **Temporal layering** – Combine graph RAG with the temporal agent approach to ensure responses reflect the most recent knowledge state.
+

--- a/docs/openai_vector_database_guides.md
+++ b/docs/openai_vector_database_guides.md
@@ -1,0 +1,12 @@
+# Vector Database Guides
+
+This document summarizes the OpenAI cookbook ["Vector Databases"](https://github.com/openai/openai-cookbook/tree/main/examples/vector_databases) directory and relates it to the Knowledge3D (K3D) project.
+
+> "This section of the OpenAI Cookbook showcases many of the vector databases available to support your semantic search use cases."
+
+## Insights for K3D
+
+1. **Pluggable storage** – Evaluate integrations for Milvus, Pinecone, Qdrant, Redis, and more as backends for storing K3D node embeddings.
+2. **Standardized patterns** – Each provider guide follows a common notebook template, helping K3D developers swap databases without rewriting ingestion code.
+3. **Scalable retrieval** – Vector stores enable fast similarity search, forming the foundation for responsive navigation and RAG within the 3D knowledge universe.
+

--- a/docs/openai_visualizing_embeddings_3d_cookbook.md
+++ b/docs/openai_visualizing_embeddings_3d_cookbook.md
@@ -1,0 +1,12 @@
+# Visualizing Embeddings in 3D
+
+This document summarizes insights from the OpenAI cookbook notebook ["Visualizing embeddings in 3D"](https://github.com/openai/openai-cookbook/blob/main/examples/Visualizing_embeddings_in_3D.ipynb) and relates them to the Knowledge3D (K3D) project.
+
+> "The example uses PCA to reduce the dimensionality of the embeddings from 1536 to 3. Then we can visualize the data points in a 3D plot."
+
+## Insights for K3D
+
+1. **Dimensionality reduction** – Apply PCA or similar techniques to project high-dimensional knowledge vectors into K3D's spatial coordinates.
+2. **Visual analytics** – Use 3D scatter plots to inspect clustering, anomaly points, or semantic regions before committing data to the K3D universe.
+3. **Educational tooling** – Provide researchers an interactive notebook template that mirrors the planned K3D viewer's rendering pipeline.
+


### PR DESCRIPTION
## Summary
- document eval-driven design, MCP voice agents, model selection and more
- link new cookbooks from README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688fcf6dbc9c83249a3319d72b037e18