### PR TITLE
docs: log external standards research

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -28,5 +28,14 @@ This file lists tasks for Codex agents working on this repository. They mirror t
 8. **Update roadmap**
    - Keep `docs/ROADMAP.md` current with milestones through 2026.
 
+## Research tasks
+
+1. **3D data standards**
+   - Evaluate repositories such as `KhronosGroup/glTF`, `PixarAnimationStudios/OpenUSD`, `CesiumGS/3d-tiles`, and `IfcOpenShell/IfcOpenShell` for license compatibility and tooling.
+2. **Graph database standards**
+   - Investigate `apache/tinkerpop`, `opencypher/openCypher`, `w3c/rdf-star`, and `neo4j/neo4j` to align query languages and schemas with K3D.
+3. **Math embedding models**
+   - Review projects like `tbs17/MathBERT` and `Jordan-Haidee/LaTeX2Vector` to support equation-level vectorization.
+
 Agents should reference this file to coordinate efforts and keep contributions aligned with the overall roadmap.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,3 +43,9 @@ In August 2025 the team adopted the **EchoSystems K3D Collaboration Action Plan
 - GIF for README: record the viewer rotating the demo cloud—30 fps, 6 s loop.
 - CI: any commit touching `/viewer` should auto‑deploy to `gh-pages`, so folks can click‑try without cloning.
 
+## Ongoing research
+
+- **3D data standards**: glTF, OpenUSD, 3D Tiles, and IfcOpenShell are under review for compatibility and reuse.
+- **Graph database standards**: TinkerPop, openCypher, RDF-star, and Neo4j will guide the K3D graph model.
+- **Math embedding models**: MathBERT and LaTeX2Vector are being evaluated for formula embeddings.
+

--- a/docs/standards_research.md
+++ b/docs/standards_research.md
@@ -1,0 +1,29 @@
+# External standards and model candidates
+
+This document lists third-party repositories under consideration for integration. Licenses and update dates were retrieved from the GitHub API on 2025-08-03.
+
+## 3D data standards
+
+| Repository | License | Last Updated |
+|-----------|---------|--------------|
+| [KhronosGroup/glTF](https://github.com/KhronosGroup/glTF) | NOASSERTION | 2025-08-02 |
+| [PixarAnimationStudios/OpenUSD](https://github.com/PixarAnimationStudios/OpenUSD) | NOASSERTION | 2025-08-02 |
+| [CesiumGS/3d-tiles](https://github.com/CesiumGS/3d-tiles) | Unknown | 2025-08-01 |
+| [IfcOpenShell/IfcOpenShell](https://github.com/IfcOpenShell/IfcOpenShell) | LGPL-3.0 | 2025-08-03 |
+
+## Graph database standards
+
+| Repository | License | Last Updated |
+|-----------|---------|--------------|
+| [apache/tinkerpop](https://github.com/apache/tinkerpop) | Apache-2.0 | 2025-08-01 |
+| [opencypher/openCypher](https://github.com/opencypher/openCypher) | Apache-2.0 | 2025-07-31 |
+| [w3c/rdf-star](https://github.com/w3c/rdf-star) | NOASSERTION | 2025-06-01 |
+| [neo4j/neo4j](https://github.com/neo4j/neo4j) | GPL-3.0 | 2025-08-03 |
+
+## Math embedding models
+
+| Repository | License | Last Updated |
+|-----------|---------|--------------|
+| [tbs17/MathBERT](https://github.com/tbs17/MathBERT) | Unknown | 2025-07-22 |
+| [Jordan-Haidee/LaTeX2Vector](https://github.com/Jordan-Haidee/LaTeX2Vector) | AGPL-3.0 | 2024-01-01 |
+


### PR DESCRIPTION
## Summary
- track research tasks for 3D, graph database, and math embedding standards
- document candidate external repositories for each area
- note ongoing research in the roadmap

## Testing
- `python -m pytest`
- `python -m k3dgen examples/sample_vectors.csv --gltf /tmp/out.gltf --k3d /tmp/out.k3d`

------
https://chatgpt.com/codex/tasks/task_e_688fe194f8ec832485921d2d33a7f254