### PR TITLE
Constrain vector and metadata in K3D schemas

### DIFF
--- a/spec/k3d_node_schema.json
+++ b/spec/k3d_node_schema.json
@@ -7,13 +7,24 @@
     "id": {"type": "string"},
     "vector": {
       "type": "array",
-      "items": {"type": "number"}
+      "items": {"type": "number"},
+      "minItems": 3,
+      "maxItems": 3
     },
-    "metadata": {"type": "object"},
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "label": {"type": "string"},
+        "type": {"type": "string"}
+      },
+      "required": ["label", "type"],
+      "additionalProperties": false
+    },
     "neighbors": {
       "type": "array",
       "items": {"type": "string"},
-      "description": "Related node identifiers"
+      "description": "Related node identifiers",
+      "uniqueItems": true
     }
   },
   "required": ["id", "vector"]

--- a/spec/k3d_schema.json
+++ b/spec/k3d_schema.json
@@ -5,8 +5,27 @@
   "type": "object",
   "properties": {
     "id": {"type": "string"},
-    "vector": {"type": "array", "items": {"type": "number"}},
-    "metadata": {"type": "object"}
+    "vector": {
+      "type": "array",
+      "items": {"type": "number"},
+      "minItems": 3,
+      "maxItems": 3
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "label": {"type": "string"},
+        "type": {"type": "string"}
+      },
+      "required": ["label", "type"],
+      "additionalProperties": false
+    },
+    "neighbors": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Related node identifiers",
+      "uniqueItems": true
+    }
   },
   "required": ["id", "vector"]
 }


### PR DESCRIPTION
## Summary
- enforce 3D vector length in node and global schemas
- restrict metadata to label and type keys
- prevent duplicate neighbor references

## Testing
- `python - <<'PY'
import json, jsonschema
for path in ['spec/k3d_node_schema.json', 'spec/k3d_schema.json']:
    schema=json.load(open(path))
    jsonschema.Draft7Validator.check_schema(schema)
    print(path, 'valid')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6891161a6ac88324afb50dbd88699cd1