### PR TITLE
doc: define glTF K3D extension

### DIFF
--- a/spec/glTF_K3D_extension.md
+++ b/spec/glTF_K3D_extension.md
@@ -1,3 +1,46 @@
 # glTF K3D Extension (Draft)
 
-This stub outlines the planned extension to glTF for embedding Knowledge3D metadata. The final specification will define how `.k3d` information can be referenced or embedded within a glTF scene.
+The `K3D_nodes` extension links a glTF scene to external `.k3d` data so that
+graph‑based knowledge can be aligned with 3D geometry. Each record in the
+`.k3d` file must validate against
+[`k3d_node_schema.json`](k3d_node_schema.json).
+
+## Properties
+
+| Property      | Type   | Description |
+|---------------|--------|-------------|
+| `uri`         | string | Relative or absolute URI of the `.k3d` file containing node entries that follow `k3d_node_schema.json`. |
+| `schema`      | string | Optional URI to a JSON schema describing the `.k3d` node format. Defaults to `k3d_node_schema.json` when omitted. |
+| `nodeProperty`| string | JSON pointer indicating where each glTF node stores the corresponding K3D `id`. Defaults to `extras.k3dId`. |
+
+## Example
+
+```json
+{
+  "extensionsUsed": ["K3D_nodes"],
+  "extensions": {
+    "K3D_nodes": {
+      "uri": "cloud.k3d",
+      "schema": "../spec/k3d_node_schema.json",
+      "nodeProperty": "extras.k3dId"
+    }
+  },
+  "nodes": [
+    { "mesh": 0, "extras": { "k3dId": "node-1" } }
+  ]
+}
+```
+
+## Rationale
+
+Separating K3D metadata into a sidecar keeps the glTF payload small while
+allowing rich graph relationships defined in
+[`k3d_node_schema.json`](k3d_node_schema.json).
+
+## Compatibility
+
+Readers that ignore `K3D_nodes` continue to operate on standard glTF content.
+The extension follows the existing `extensionsUsed`/`extensionsRequired`
+mechanism and is compatible with other extensions such as
+`KHR_draco_mesh_compression`.
+


### PR DESCRIPTION
## Summary
- describe `K3D_nodes` glTF extension for linking `.k3d` data
- document extension properties and example usage
- explain rationale and compatibility with existing glTF extensions

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_689116e5017c8324bd1168ef43764693