### PR TITLE
Add CLI test and CI workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pytest flake8 black
+      - name: Lint
+        run: |
+          flake8
+          black --check .
+      - name: Test
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Knowledge3D
 
-| Status | License |
-| ------ | ------- |
-| ![pre-alpha](https://img.shields.io/badge/status-pre--alpha-blue) | [Apache-2.0](LICENSE) |
+| Status | CI | License |
+| ------ | -- | ------- |
+| ![pre-alpha](https://img.shields.io/badge/status-pre--alpha-blue) | [![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/ci.yml) | [Apache-2.0](LICENSE) |
 
 Knowledge3D (K3D) is an initiative from EchoSystems AI Studios to build an open standard and toolkit for rendering artificial intelligence knowledge as a navigable three‑dimensional universe.  It fuses concepts from CAD geometry, vector databases and augmented‑reality mapping so humans and AI models can explore data side by side.
 

--- a/k3dgen/__main__.py
+++ b/k3dgen/__main__.py
@@ -80,8 +80,7 @@ def generate(csv_path: str, gltf_path: str, k3d_path: str) -> None:
         raise ValueError(f"PCA computation failed: {exc}") from exc
 
     records = [
-        {"id": i, "vector": vec.tolist(), "metadata": {}}
-        for i, vec in zip(ids, points)
+        {"id": i, "vector": vec.tolist(), "metadata": {}} for i, vec in zip(ids, points)
     ]
     try:
         with open(k3d_path, "w", encoding="utf-8") as f:
@@ -96,7 +95,9 @@ def generate(csv_path: str, gltf_path: str, k3d_path: str) -> None:
         "ascii"
     )
     buffer = Buffer(byteLength=len(data_bytes), uri=uri)
-    view = BufferView(buffer=0, byteOffset=0, byteLength=len(data_bytes), target=ARRAY_BUFFER)
+    view = BufferView(
+        buffer=0, byteOffset=0, byteLength=len(data_bytes), target=ARRAY_BUFFER
+    )
     accessor = Accessor(
         bufferView=0,
         byteOffset=0,
@@ -154,5 +155,5 @@ def main() -> None:
         parser.exit(1, f"Error: {exc}\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,7 @@ k3dgen = "k3dgen.__main__:main"
 
 [tool.setuptools]
 packages = ["k3dgen"]
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203"]

--- a/tests/test_k3dgen.py
+++ b/tests/test_k3dgen.py
@@ -1,0 +1,39 @@
+import json
+import subprocess
+from pathlib import Path
+
+from pygltflib import GLTF2
+
+
+def test_cli_generates_files(tmp_path):
+    csv_path = Path("examples/sample_vectors.csv")
+    gltf_out = tmp_path / "out.gltf"
+    k3d_out = tmp_path / "out.k3d"
+
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "k3dgen",
+            str(csv_path),
+            "--gltf",
+            str(gltf_out),
+            "--k3d",
+            str(k3d_out),
+        ],
+        check=True,
+    )
+
+    assert gltf_out.is_file()
+    assert k3d_out.is_file()
+
+    data = json.loads(k3d_out.read_text())
+    expected = sum(1 for _ in open(csv_path)) - 1
+    assert len(data) == expected
+    assert all("id" in r and "vector" in r and "metadata" in r for r in data)
+    assert all(len(r["vector"]) == 3 for r in data)
+
+    gltf = GLTF2().load(str(gltf_out))
+    assert gltf.asset.version == "2.0"
+    assert len(gltf.meshes) == 1
+    assert len(gltf.nodes) == 1


### PR DESCRIPTION
## Summary
- add pytest verifying `k3dgen` CLI builds `.k3d` and glTF files
- run lint and tests in new GitHub Actions workflow
- display workflow badge in README

## Testing
- `flake8`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689117d4c3808324a542c07bfd3a78eb