### PR TITLE
Validate positive neighbor counts in k3dgen

### DIFF
--- a/k3dgen/__main__.py
+++ b/k3dgen/__main__.py
@@ -67,6 +67,8 @@ def reduce_dimensions(vectors: np.ndarray) -> np.ndarray:
 
 def find_neighbors(vectors: np.ndarray, k: int) -> np.ndarray:
     """Find the k-nearest neighbors for each vector."""
+    if k <= 0:
+        raise ValueError("k must be a positive integer")
     if k >= len(vectors):
         raise ValueError("k must be less than the number of vectors")
     nn = NearestNeighbors(n_neighbors=k + 1, algorithm="auto")

--- a/tests/test_k3dgen.py
+++ b/tests/test_k3dgen.py
@@ -56,3 +56,21 @@ def test_cli_generates_files(tmp_path):
     primitive = gltf.meshes[0].primitives[0]
     assert "k3dIds" in primitive.extras
     assert len(primitive.extras["k3dIds"]) == expected_records
+
+
+def test_cli_negative_k(tmp_path):
+    csv_path = Path("examples/sample_vectors.csv")
+    result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "k3dgen",
+            str(csv_path),
+            "--k",
+            "-1",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "positive integer" in result.stderr


### PR DESCRIPTION
## Summary
- guard against non-positive `k` values in neighbor search
- test CLI for negative `k`

## Testing
- `flake8 k3dgen/__main__.py tests/test_k3dgen.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c1c27cc1c83248f3fb50947a09af8