### PR TITLE
Handle nested meshes in viewer scene traversal

### DIFF
--- a/viewer/src/findFirstMesh.ts
+++ b/viewer/src/findFirstMesh.ts
@@ -1,0 +1,16 @@
+import * as THREE from 'three';
+
+/**
+ * Traverses the scene to find the first THREE.Mesh instance.
+ * @param root - Root object to begin traversal from.
+ * @returns The first mesh found, or undefined if none exists.
+ */
+export function findFirstMesh(root: THREE.Object3D): THREE.Mesh | undefined {
+  let found: THREE.Mesh | undefined;
+  root.traverse((obj) => {
+    if (!found && (obj as THREE.Mesh).isMesh) {
+      found = obj as THREE.Mesh;
+    }
+  });
+  return found;
+}

--- a/viewer/src/main.ts
+++ b/viewer/src/main.ts
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { fetchK3D, type K3DRecord } from './loadK3D';
+import { findFirstMesh } from './findFirstMesh';
 
 // --- Constants ---
 const K3D_EXTENSION_NAME = 'K3D_nodes';
@@ -51,7 +52,7 @@ loader.load(gltfUrl, async (gltf) => {
   }
 
   // 2. Extract geometry and IDs from glTF
-  const mesh = gltf.scene.children[0] as THREE.Mesh;
+  const mesh = findFirstMesh(gltf.scene);
   if (!mesh) {
     console.error('No mesh found in glTF scene.');
     return;

--- a/viewer/tests/findFirstMesh.test.ts
+++ b/viewer/tests/findFirstMesh.test.ts
@@ -1,0 +1,21 @@
+import * as THREE from 'three';
+import { findFirstMesh } from '../src/findFirstMesh';
+
+describe('findFirstMesh', () => {
+  it('finds the first mesh in a nested scene graph', () => {
+    const root = new THREE.Group();
+    const group = new THREE.Group();
+    root.add(group);
+    const mesh = new THREE.Mesh(new THREE.BufferGeometry());
+    group.add(mesh);
+
+    expect(findFirstMesh(root)).toBe(mesh);
+  });
+
+  it('returns undefined when no mesh is present', () => {
+    const root = new THREE.Group();
+    root.add(new THREE.Object3D());
+
+    expect(findFirstMesh(root)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Traverse GLTF scene to locate the first mesh instead of assuming the first child
- Fail gracefully when no mesh is found
- Add `findFirstMesh` helper and unit tests for nested node structures

## Testing
- `npm --prefix viewer test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c202e51788324ba2c8decd606c628