### PR TITLE
Add house memory documentation and cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The ideas behind K3D are explored in more detail in the following documents:
 -   [A 3D Vector Universe Standard for High-Dimensional AI Knowledge](docs/papers/3d_vector_universe_standard.docx) (Whitepaper)
 -   [Developer Guidelines](docs/DEV_GUIDELINES.md)
 -   [Codex Tasks](CODEX.md)
+-   [House Memory: Linking LLM Embeddings to the Spatial Web](docs/HOUSE_MEMORY.md)
 
 A full list of related papers and research can be found in the `docs/` directory.
 

--- a/docs/HOUSE_MEMORY.md
+++ b/docs/HOUSE_MEMORY.md
@@ -1,0 +1,19 @@
+# House Memory: Linking LLM Embeddings to the Spatial Web
+
+The **house metaphor** imagines a large language model as a dwelling with many rooms. Each attention head holds a key that opens a specific room where knowledge is stored. As a conversation unfolds, the model walks through these rooms, retrieving context from its internal memory.
+
+## LLM Heads to K3D Nodes
+
+K3D externalizes those rooms into a spatial web. Head embeddings become **K3D nodes**, allowing long‑term memories to live outside the core model. Each node records the head, its embedding, and spatial coordinates that place the memory within the knowledgeverse.
+
+## Offloading to Reduce Core Model Size
+
+By offloading seldom‑used knowledge to the K3D house, the core model can remain lightweight. Instead of expanding parameters to remember everything, the model fetches relevant rooms from the spatial web when needed, reducing overall size while retaining access to rich context.
+
+## LLM ↔ House ↔ Spatial Web Flow
+
+```mermaid
+graph LR
+    LLM["LLM Head Embeddings"] <--> House["House Memory\n(K3D Nodes)"]
+    House <--> Web["Spatial Web"]
+```

--- a/docs/Jules_Report.md
+++ b/docs/Jules_Report.md
@@ -18,6 +18,8 @@ The K3D project is more than just a 3D data viewer; it is the blueprint for a **
 
 This spatial metaphor is not merely a visualization gimmick; it is a fundamental re-imagining of the user interface for knowledge work. By mapping the abstract relationships in high-dimensional data to the intuitive geometry of 3D space, we can unlock new ways of thinking and problem-solving.
 
+For a discussion of how LLM head embeddings can be externalized into K3D nodes using a house metaphor, see [House Memory](HOUSE_MEMORY.md).
+
 ## 2. The K3D Standard: A Foundation for Spatial Knowledge
 
 The K3D standard is the technical bedrock of this vision. It is a simple yet powerful fusion of two key technologies:


### PR DESCRIPTION
## Summary
- document house metaphor linking LLM head embeddings to K3D nodes and showing how offloading reduces model size
- include mermaid diagram of LLM ↔ House ↔ Spatial Web flow
- link new doc from README and Jules Report

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c263467008324a63ce731585c0666